### PR TITLE
feat: refactor so usage is now through a client

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/Thumbscrew/ecs-task-protection
 
-go 1.20
+go 1.21
+
+toolchain go1.22.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.4


### PR DESCRIPTION
Changes:
- Bump module to go 1.21
- Use client to make calls
- Move `Context` out of `UpdateTaskProtectionInput`